### PR TITLE
Update richmarker.js

### DIFF
--- a/src/richmarker.js
+++ b/src/richmarker.js
@@ -729,13 +729,13 @@ RichMarker.prototype.onAdd = function() {
 
     var that = this;
     google.maps.event.addDomListener(this.markerContent_, 'click', function(e) {
-      google.maps.event.trigger(that, 'click');
+      google.maps.event.trigger(that, 'click', e);
     });
     google.maps.event.addDomListener(this.markerContent_, 'mouseover', function(e) {
-      google.maps.event.trigger(that, 'mouseover');
+      google.maps.event.trigger(that, 'mouseover', e);
     });
     google.maps.event.addDomListener(this.markerContent_, 'mouseout', function(e) {
-      google.maps.event.trigger(that, 'mouseout');
+      google.maps.event.trigger(that, 'mouseout', e);
     });
   }
 


### PR DESCRIPTION
Sometimes is necessary to stop the propagation. For example if there are a click listener bind to the map and you dont want to trigger when the marker is clicked.
