### PR TITLE
Update richmarker.js to send marker as argument to 'dragend' callback

### DIFF
--- a/src/richmarker.js
+++ b/src/richmarker.js
@@ -526,7 +526,7 @@ RichMarker.prototype.stopDrag = function() {
     this.removeDraggingListeners_();
 
     this.setCursor_('draggable');
-    google.maps.event.trigger(this, 'dragend');
+    google.maps.event.trigger(this, 'dragend', this);
 
     this.draw();
   }


### PR DESCRIPTION
Unless the marker object is sent as an argument in the callback, you can only use anonymous functions which have the marker in scope.

``` javascript
google.maps.event.addListener(marker, 'dragend', function() {
  marker.getPosition() // do something with new marker location
});
```

I see no problem with sending the marker as an argument to the callback, it's what the normal Google Maps markers do. With this simple change we can do something like the following.

``` javascript
function dragendCallback(marker) {
  marker.getPosition() // do something with new marker location
}

// Somewhere else where the marker is created
google.maps.event.addListener(marker, 'dragend', dragendCallback);
```

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.svg" height="40" alt="Review on Reviewable"/>](https://reviewable.io/reviews/googlemaps/js-rich-marker/5)

<!-- Reviewable:end -->
